### PR TITLE
Check if there are running containers to avoid inspect error

### DIFF
--- a/docker-hostnames.sh
+++ b/docker-hostnames.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env sh
 
-sed -i '/\#dockerhostnames/d' /etc/hosts && echo "$(docker ps -q | xargs -n 1 docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}} {{ .Name }} #dockerhostnames' | sed 's/ \// /')" | tee -a /etc/hosts
+sed -i '/\#dockerhostnames/d' /etc/hosts &&
+  [ "$(docker ps -q)" ] &&
+  docker ps -q |
+    xargs -n 1 docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}} {{ .Name }} #dockerhostnames' |
+    sed 's/ \// /' |
+    tee -a /etc/hosts


### PR DESCRIPTION
I was having this error when I run the script and there were no running containers:

    $ sudo ./docker-hostnames.sh 
    "docker inspect" requires at least 1 argument.
    See 'docker inspect --help'.

    Usage:  docker inspect [OPTIONS] NAME|ID [NAME|ID...]

    Return low-level information on Docker objects
